### PR TITLE
add wrap_time_allowed to industrial dataset config

### DIFF
--- a/project/project.json5
+++ b/project/project.json5
@@ -55,6 +55,7 @@
         },
         {
             dataset_id: 'decarb_2023_industry',
+	    wrap_time_allowed: true,
             dataset_type: 'modeled',
             version: '1.0.0',
             required_dimensions: {


### PR DESCRIPTION
Correct bug in dataset config in project.json5: industrial dataset needs to set `wrap_time_allowed: true`
Related to [dsgrid issue #313](https://github.com/dsgrid/dsgrid/issues/313)